### PR TITLE
Monorepo Conversion and Node.js 22 Upgrade

### DIFF
--- a/cdk-minimal-policy.json
+++ b/cdk-minimal-policy.json
@@ -1,0 +1,76 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CdkBootstrapRoleAssumption",
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": "arn:aws:iam::*:role/cdk-hnb659fds-*"
+    },
+    {
+      "Sid": "SSMBootstrapManagement",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:PutParameter",
+        "ssm:AddTagsToResource"
+      ],
+      "Resource": "arn:aws:ssm:*:*:parameter/cdk-bootstrap/hnb659fds/*"
+    },
+    {
+      "Sid": "CdkCliReadiness",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:Describe*",
+        "cloudformation:Get*",
+        "cloudformation:List*",
+        "cloudformation:ValidateTemplate",
+        "acm:ListCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PlanningPokerManagement",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:*",
+        "iam:*",
+        "lambda:*",
+        "apigateway:*",
+        "dynamodb:*",
+        "secretsmanager:*",
+        "s3:*",
+        "ecr:*",
+        "acm:*",
+        "route53:*",
+        "logs:*"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:*:*:stack/PlanningPoker*/*",
+        "arn:aws:cloudformation:*:*:stack/CDKToolkit/*",
+        "arn:aws:iam::*:role/PlanningPoker*",
+        "arn:aws:iam::*:policy/PlanningPoker*",
+        "arn:aws:iam::*:role/cdk-hnb659fds-*",
+        "arn:aws:lambda:*:*:function:PlanningPoker*",
+        "arn:aws:dynamodb:*:*:table/PlanningPoker*",
+        "arn:aws:secretsmanager:*:*:secret:PlanningPoker*",
+        "arn:aws:s3:::cdk-hnb659fds-assets-*",
+        "arn:aws:ecr:*:*:repository/cdk-hnb659fds-*",
+        "arn:aws:apigateway:*::/*",
+        "arn:aws:logs:*:*:log-group:/aws/lambda/PlanningPoker*",
+        "arn:aws:logs:*:*:log-group:PlanningPoker*"
+      ]
+    },
+    {
+      "Sid": "IamPassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": [
+        "arn:aws:iam::*:role/PlanningPoker*",
+        "arn:aws:iam::*:role/cdk-hnb659fds-*"
+      ]
+    }
+  ]
+}

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build --workspace=cdk"
+    "build": "npm run build --workspace=cdk",
+    "deploy": "npm run deploy --workspace=cdk"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",


### PR DESCRIPTION
## Monorepo Conversion and Dependency Upgrades

This PR converts the project into an npm workspaces monorepo and upgrades all components to Node.js 22 with the latest stable dependencies.

### Key Changes:
- **Monorepo Structure**: Established an npm workspaces structure (`cdk`, `lambda-src`) with consolidated root-level configurations for TypeScript, ESLint 9, and Jest.
- **Node.js 22 Upgrade**: Updated all Lambda functions and CDK code to target the Node 22 runtime.
- **CDK Refactoring**: 
    - Resolved all deprecation warnings (e.g., `logRetention`, `DnsValidatedCertificate`).
    - Implemented a DRY `createPlanningPokerFunction` helper to manage Lambda and LogGroup creation with consistent 3-day retention policies.
- **Dependency Upgrades**: Upgraded core libraries including `@slack/bolt` (v4), `aws-cdk-lib`, and various AWS SDK components.
- **IAM Policy**: Added `cdk-minimal-policy.json` representing the least-privilege permissions required for deployment.

### Verification:
- Successfully ran `npm run lint` and `npm run build` from the monorepo root.
- Verified infrastructure synthesis via `cdk synth`.
- Successfully deployed the entire stack to AWS after resolving initial bootstrap and IAM hurdles.
